### PR TITLE
Seek option in audio transcode

### DIFF
--- a/src/services/Transcode.php
+++ b/src/services/Transcode.php
@@ -366,6 +366,10 @@ class Transcode extends Component
             }
             $ffmpegCmd .= ' '.$thisEncoder['audioCodecOptions'];
 
+            if (!empty($audioOptions['seekInSecs'])) {
+                $ffmpegCmd .= ' -ss '.$audioOptions['seekInSecs'];
+            }
+
             if (!empty($audioOptions['timeInSecs'])) {
                 $ffmpegCmd .= ' -t '.$audioOptions['timeInSecs'];
             }


### PR DESCRIPTION
Added option for seeking, so the «cropped» mp3 will start at a given point, and run for `timeInSecs`