### PR TITLE
Fix GIF filename generation

### DIFF
--- a/src/services/Transcode.php
+++ b/src/services/Transcode.php
@@ -57,6 +57,7 @@ class Transcode extends Component
         'sharpen',
         'synchronous',
         'stripMetadata',
+        'videoCodecOptions',
     ];
 
     // Mappings for getFileInfo() summary values


### PR DESCRIPTION
GIF filename incluced `videoCocecOptions` (e.g. `-pix_fmt yuv420p -movflags +faststart -filter:v crop=\'floor(in_w/2)*2:floor(in_h/2)*2\' `)

Do not include this param in the filename